### PR TITLE
sphinx-render-docs-action MWE

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build
         shell: bash -l {0}
         run: |
-          conda install sphinx myst-nb sphinx-rtd-theme -c conda-forge
+          conda install sphinx myst-nb sphinx-rtd-theme sphinx-book-theme -c conda-forge
           sphinx-build -M html ./docs/source ./_build
              
       - name: GitHub Pages action

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,24 +1,57 @@
 name: "Sphinx: Render docs"
 
-on: push
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
+      tags:
+        description: 'Test scenario tags'
+        required: false
+        type: boolean
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
+  push:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    strategy:
+      matrix:
+        python-version: [3.12]
+
     steps:
-    - uses: actions/checkout@v4
-    - name: Build HTML
-      uses: ammaraskar/sphinx-action@master
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: html-docs
-        path: docs/build/html/
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          #environment-file: geomod.yaml
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge,defaults
+          channel-priority: true
+          auto-activate-base: false
+          
+      - name: Build
+        shell: bash -l {0}
+        run: |
+          conda install sphinx myst-nb sphinx-rtd-theme -c conda-forge
+          sphinx-build -M html ./docs/source ./_build
+             
+      - name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_build/html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,5 +23,5 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_book_theme' # for the original theme: 'sphinx_rtd_theme'
 html_static_path = ['_static']


### PR DESCRIPTION
Changes:
- updated sphinx-render-docs-action to work with the MWE provided by the repo.
- Code installs a minimal conda/mamba environment, and installs the requested packages therein. Then run Sphinx-build and uses GH actions to move the generated HTML files to the GH pages branch for page access.
Example at: https://peterbetlem.github.io/RecipeTest/index.html